### PR TITLE
fix: ホットリロード時にインスタンスが無限に生成されるのを修正

### DIFF
--- a/lib/prisma/prisma-client.ts
+++ b/lib/prisma/prisma-client.ts
@@ -1,3 +1,16 @@
+// 吉井 健文. 実践Next.js —— App Routerで進化するWebアプリ開発 エンジニア選書 (p.682). 株式会社技術評論社. Kindle 版.
 import { PrismaClient } from "@prisma/client";
 
-export const prisma = new PrismaClient();
+const prismaClientSingleton = () => {
+  return new PrismaClient();
+};
+
+type PrismaClientSingleton = ReturnType<typeof prismaClientSingleton>;
+
+const globalForPrisma = globalThis as unknown as {
+  prisma: PrismaClientSingleton | undefined;
+};
+
+export const prisma = globalForPrisma.prisma ?? prismaClientSingleton();
+
+if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;


### PR DESCRIPTION
# WHY
・ホットリロード時にPrismaClientのインスタンスが無限に生成されてしまってエラーが出るため

# WHAT
・無限に生成されないように修正