### PR TITLE
Topicテーブルの追加と全トピックを取得するAPIの作成

### DIFF
--- a/app/api/topic/get/route.ts
+++ b/app/api/topic/get/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { Topic } from "@/type";
 import { prisma } from "@/lib/prisma/prisma-client";
 
-export async function fetchAllTopics(): Promise<Topic[]> {
+async function fetchAllTopics(): Promise<Topic[]> {
   try {
     const topics: Topic[] = await prisma.$queryRaw<Topic[]>`
       SELECT * FROM "Topics" ORDER BY created_at DESC;

--- a/app/api/topic/get/route.ts
+++ b/app/api/topic/get/route.ts
@@ -17,7 +17,10 @@ async function fetchAllTopics(): Promise<Topic[]> {
 export async function GET(request: NextRequest): Promise<NextResponse> {
   try {
     const topics = await fetchAllTopics();
-    return NextResponse.json(topics);
+    return NextResponse.json(
+      topics, 
+      { status: 200 }
+    );
   } catch (error) {
     console.error(error);
     return NextResponse.json(

--- a/app/api/topic/get/route.ts
+++ b/app/api/topic/get/route.ts
@@ -17,7 +17,10 @@ async function fetchAllTopics(): Promise<Topic[]> {
 export async function GET(request: NextRequest): Promise<NextResponse> {
   try {
     const topics = await fetchAllTopics();
-    return NextResponse.json(topics);
+    return NextResponse.json(
+      topics, 
+      {status: 200}
+    );
   } catch (error) {
     console.error(error);
     return NextResponse.json(

--- a/app/api/topic/get/route.ts
+++ b/app/api/topic/get/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Topic } from "@/type";
+import { prisma } from "@/lib/prisma/prisma-client";
+
+export async function fetchAllTopics(): Promise<Topic[]> {
+  try {
+    const topics: Topic[] = await prisma.$queryRaw<Topic[]>`
+      SELECT * FROM "Topics" ORDER BY created_at DESC;
+    `;
+    return topics;
+  } catch (error) {
+    console.error(error);
+    throw new Error("Failed to fetch all topics.");
+  }
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const topics = await fetchAllTopics();
+    return NextResponse.json(topics);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json(
+      { error: "Failed to fetch all topics." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/topic/get/route.ts
+++ b/app/api/topic/get/route.ts
@@ -19,7 +19,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     const topics = await fetchAllTopics();
     return NextResponse.json(
       topics, 
-      {status: 200}
+       { status: 200 }
     );
   } catch (error) {
     console.error(error);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,71 +9,124 @@ generator client {
 }
 
 datasource db {
-  provider          = "postgresql"
-  url               = env("DATABASE_URL")
-  directUrl         = env("DIRECT_URL")
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
 }
 
 model Affiliations {
-  id Int @id @default(autoincrement()) @db.Integer
-  name String @db.Text
-  users Users[]
-  created_at DateTime @default(now()) @db.Timestamptz()
+  id                  Int                   @id @default(autoincrement())
+  name                String
+  created_at          DateTime              @default(now()) @db.Timestamptz(6)
+  AffiliationsToUsers AffiliationsToUsers[]
 }
 
 model Comments {
-  id Int @id @default(autoincrement()) @db.Integer
-  content String @db.Text
-  review Reviews @relation(fields: [review_id], references: [id])
-  review_id Int @db.Integer
-  user Users @relation(fields: [user_id], references: [id])
-  user_id String @db.Text
-  created_at DateTime @default(now()) @db.Timestamptz()
+  id         Int      @id @default(autoincrement())
+  content    String
+  review_id  Int
+  user_id    String
+  created_at DateTime @default(now()) @db.Timestamptz(6)
+  review     Reviews  @relation(fields: [review_id], references: [id])
+  user       Users    @relation(fields: [user_id], references: [id])
 }
 
 model Fields {
-  id Int @id @default(autoincrement()) @db.Integer
-  name String @db.Text
-  users Users[]
-  created_at DateTime @default(now()) @db.Timestamptz()
+  id            Int             @id @default(autoincrement())
+  name          String
+  created_at    DateTime        @default(now()) @db.Timestamptz(6)
+  FieldsToUsers FieldsToUsers[]
+}
+
+model Topics {
+  id            Int             @id @default(autoincrement())
+  name          String
+  created_at    DateTime        @default(now()) @db.Timestamptz(6)
+  TopicsToUsers TopicsToUsers[]
 }
 
 model Reviews {
-  id Int @id @default(autoincrement()) @db.Integer
-  content String? @db.Text
-  paper_data Json @db.JsonB
-  paper_title String @db.Text
-  thumbnail_url String? @db.Text
-  user Users @relation(fields: [user_id], references: [id])
-  user_id String @db.Text
-  comments Comments[]
-  tags Tags[]
-  created_at DateTime @default(now()) @db.Timestamptz()
+  id            Int             @id @default(autoincrement())
+  content       String?
+  paper_data    Json
+  paper_title   String
+  thumbnail_url String?
+  user_id       String
+  created_at    DateTime        @default(now()) @db.Timestamptz(6)
+  comments      Comments[]
+  user          Users           @relation(fields: [user_id], references: [id])
+  ReviewsToTags ReviewsToTags[]
 }
 
 model Tags {
-  id Int @id @default(autoincrement()) @db.Integer
-  name String @unique
-  reviews Reviews[]
-  created_at DateTime @default(now()) @db.Timestamptz()
+  id            Int             @id @default(autoincrement())
+  name          String          @unique
+  created_at    DateTime        @default(now()) @db.Timestamptz(6)
+  ReviewsToTags ReviewsToTags[]
 }
 
 model Users {
-  id String @id @db.Text @unique
-  name String @db.Text
-  role String? @db.Text
-  reviews Reviews[]
-  comments Comments[]
-  works Works[]
-  affiliations Affiliations[]
-  fields Fields[]
-  created_at DateTime @default(now()) @db.Timestamptz()
+  id                  String                @id @unique
+  name                String
+  role                String?
+  created_at          DateTime              @default(now()) @db.Timestamptz(6)
+  comments            Comments[]
+  reviews             Reviews[]
+  works               Works[]
+  AffiliationsToUsers AffiliationsToUsers[]
+  FieldsToUsers       FieldsToUsers[]
+  TopicsToUsers       TopicsToUsers[]
 }
 
 model Works {
-  id Int @id @default(autoincrement()) @db.Integer
-  url String? @db.Text
-  user Users @relation(fields: [user_id], references: [id])
-  user_id String @db.Text
-  created_at DateTime @default(now()) @db.Timestamptz()
+  id         Int      @id @default(autoincrement())
+  url        String?
+  user_id    String
+  created_at DateTime @default(now()) @db.Timestamptz(6)
+  user       Users    @relation(fields: [user_id], references: [id])
 }
+
+model AffiliationsToUsers {
+  affiliation_id Int
+  user_id        String
+  Affiliations   Affiliations @relation(fields: [affiliation_id], references: [id], onDelete: Cascade, map: "_AffiliationsToUsers_A_fkey")
+  Users          Users        @relation(fields: [user_id], references: [id], onDelete: Cascade, map: "_AffiliationsToUsers_B_fkey")
+
+  @@unique([affiliation_id, user_id], map: "_AffiliationsToUsers_AB_unique")
+  @@index([user_id], map: "_AffiliationsToUsers_B_index")
+  @@map("_AffiliationsToUsers")
+}
+
+model FieldsToUsers {
+  field_id Int
+  user_id  String
+  Fields   Fields @relation(fields: [field_id], references: [id], onDelete: Cascade, map: "_FieldsToUsers_A_fkey")
+  Users    Users  @relation(fields: [user_id], references: [id], onDelete: Cascade, map: "_FieldsToUsers_B_fkey")
+
+  @@unique([field_id, user_id], map: "_FieldsToUsers_AB_unique")
+  @@index([user_id], map: "_FieldsToUsers_B_index")
+  @@map("_FieldsToUsers")
+}
+
+model TopicsToUsers {
+  topic_id Int
+  user_id  String
+  Topics   Topics @relation(fields: [topic_id], references: [id], onDelete: Cascade, map: "_TopicsToUsers_A_fkey")
+  Users    Users  @relation(fields: [user_id], references: [id], onDelete: Cascade, map: "_TopicsToUsers_B_fkey")
+
+  @@unique([topic_id, user_id], map: "_TopicsToUsers_AB_unique")
+  @@index([user_id], map: "_TopicsToUsers_B_index")
+  @@map("_TopicsToUsers")
+}
+
+model ReviewsToTags {
+  review_id Int
+  tag_id    Int
+  Reviews   Reviews @relation(fields: [review_id], references: [id], onDelete: Cascade, map: "_ReviewsToTags_A_fkey")
+  Tags      Tags    @relation(fields: [tag_id], references: [id], onDelete: Cascade, map: "_ReviewsToTags_B_fkey")
+
+  @@unique([review_id, tag_id], map: "_ReviewsToTags_AB_unique")
+  @@index([tag_id], map: "_ReviewsToTags_B_index")
+  @@map("_ReviewsToTags")
+}
+

--- a/type/index.ts
+++ b/type/index.ts
@@ -33,6 +33,13 @@ export type Field = {
   created_at: string | Date;
 };
 
+// Topics Table: id, name, created_at
+export type Topic = {
+  id: number;
+  name: string;
+  created_at: string | Date;
+};
+
 // Reviews Table: id, content, paper_data, paper_title, user_id, created_at, thumbnail_url
 export type Review = {
   id: number;
@@ -44,7 +51,7 @@ export type Review = {
   tags: Tag[];
   created_at: string | Date;
   thumbnail_url: string | null;
-}
+};
 
 // Tags Table: id, name, user_id, created_at
 export type Tag = {
@@ -52,7 +59,7 @@ export type Tag = {
   name: string;
   user_id: string;
   created_at: string | Date;
-}
+};
 
 // Users Table: id, user_id, name, role, created_at
 export type User = {
@@ -60,7 +67,7 @@ export type User = {
   name: string;
   role: string | null; // いったん　Student or Teacher
   created_at: string | Date;
-}
+};
 
 // Works Table: id, url, user_id, created_at
 export type Work = {
@@ -68,4 +75,4 @@ export type Work = {
   url: string | null;
   user_id: string;
   created_at: string | Date;
-}
+};


### PR DESCRIPTION
# 概要
Topicテーブルの追加し、DBから全トピックを取得するAPIの作成を行った。
# やったこと
- schema.prismaを書き換え、Topicsテーブル,_TopicsToUsersテーブルを追加した
- DBから全トピックを取得するAPIを、/api/topic/get に追加した。
# 特にレビューしてほしいところ
- 特にはなし
# 保留していること
- なし
# 動作確認
- APIの動作確認済み。ゲストに仮データ登録して全部取得できてた。