### PR TITLE
レビュー操作の再実装：APIを使ってレビューをGET・UPDATE・Deleteする 

### DIFF
--- a/actions/review.action.ts
+++ b/actions/review.action.ts
@@ -31,28 +31,12 @@ export async function fetchAllReviews(): Promise<Review[]> {
   }
 }
 
-/*
-export async function fetchReview(reviewId: string) {
-  try {
-    const reviewData = await getDoc(doc(db, `reviews/${reviewId}`));
-    if (reviewData.exists()) {
-      return reviewData.data() as Review;
-    } else {
-      throw new Error("Failed to fetch review.");
-    }
-  } catch (error) {
-    console.log(error);
-    throw new Error("Failed to fetch review.");
-  }
-}
-*/
-
 export async function getReview(reviewId: number) {
   try {
     // どれが正解？
     // ブランチをマージしたらコメントを外し正しいエンドポイントを指定する
     // const review = await fetch(`/api/review/${reviewId}`)
-    // const review = await fetch(`https://kanso-batake.vercel.app//api/review/${reviewId}`)
+    // const review = await fetch(`https://kanso-batake.vercel.app/api/review/${reviewId}`)
     // const review = await fetch(`http://localhost:3000/api/review/${reviewId}`);
     const review = await fetch(
       `http://localhost:3000/api/review/get/${reviewId}`,
@@ -106,34 +90,26 @@ export async function setReview(
   redirect(`/user/${auth_userId}`);
 }
 
-/*
-export async function updateReview(
-  userId: string,
-  reviewData: Review
-) {
-  await Promise.all([
-    updateDoc(doc(db, `reviews/${reviewData.id}`), reviewData),
-    updateDoc(doc(db, `users/${userId}/reviews/${reviewData.id}`), reviewData),
-  ]);
-
-  revalidatePath(`/user/${userId}`);
-  redirect(`/user/${userId}`);
-}
-*/
-
-export async function updateReview(userId: string, reviewData: Review) {
+export async function updateReview(reviewData: Review) {
   try {
-    await prisma.$executeRaw`
-        UPDATE "Reviews" 
-        SET content = ${reviewData.content}, paper_data = ${reviewData.paper_data}, paper_title = ${reviewData.paper_title}, user_id = ${reviewData.user_id}, thumbnail_url = ${reviewData.thumbnail_url}
-        WHERE id = ${reviewData.id};`;
+    // どれが正解？
+    // ブランチをマージしたらコメントを外し正しいエンドポイントを指定する
+    // const review = await fetch(`/api/review/${reviewId}`)
+    // const review = await fetch(`https://kanso-batake.vercel.app/api/review/${reviewId}`)
+    const res = await fetch(
+      `http://localhost:3000/api/review/${reviewData.id}`,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ reviewData }),
+      },
+    );
   } catch (error) {
     console.log(error);
-    throw new Error("Failed to set review.");
+    throw new Error("Failed to update review.");
   }
-
-  revalidatePath(`/user/${userId}`);
-  redirect(`/user/${userId}`);
 }
 
 /*

--- a/actions/review.action.ts
+++ b/actions/review.action.ts
@@ -50,8 +50,10 @@ export async function fetchReview(reviewId: string) {
 export async function getReview(reviewId: number) {
   try {
     // どれが正解？
-    // const review = await fetch(`/api/review/get/${reviewId}`)
-    // const review = await fetch(`https://kanso-batake.vercel.app//api/review/get/${reviewId}`)
+    // ブランチをマージしたらコメントを外し正しいエンドポイントを指定する
+    // const review = await fetch(`/api/review/${reviewId}`)
+    // const review = await fetch(`https://kanso-batake.vercel.app//api/review/${reviewId}`)
+    // const review = await fetch(`http://localhost:3000/api/review/${reviewId}`);
     const review = await fetch(
       `http://localhost:3000/api/review/get/${reviewId}`,
     );

--- a/actions/review.action.ts
+++ b/actions/review.action.ts
@@ -47,6 +47,16 @@ export async function fetchReview(reviewId: string) {
 }
 */
 
+export async function getReview(reviewId: number) {
+  try {
+    const review = await fetch(`api/review/get/${reviewId}`);
+    return review;
+  } catch (error) {
+    console.log(error);
+    throw new Error("Failed to fetch review.");
+  }
+}
+
 export async function fetchReview(reviewId: number): Promise<Review[]> {
   try {
     const reviewData = await prisma.$queryRaw<Review[]>`
@@ -73,7 +83,7 @@ export async function setReview(userId: string, reviewData: Review) {
 
 export async function setReview(
   auth_userId: string,
-  reviewData: Review
+  reviewData: Review,
 ): Promise<Review[]> {
   try {
     await prisma.$executeRaw<Review[]>`
@@ -258,7 +268,7 @@ export async function fetchReviewsByTagAndUser(
 
 export async function fetchReviewsByTagAndUser(
   searchTag: string,
-  userId: string
+  userId: string,
 ): Promise<Review[]> {
   try {
     const reviewsData = await prisma.$queryRaw<Review[]>`
@@ -279,7 +289,7 @@ export async function fetchReviewsByTagAndUser(
 
 export async function fetchReviewsByFilter(
   searchTag?: string,
-  userId?: string
+  userId?: string,
 ): Promise<Review[]> {
   try {
     if (!searchTag && !userId) {
@@ -302,7 +312,7 @@ export async function fetchReviewsByFilter(
 }
 
 export async function fetchReviewsByAffiliationId(
-  affiliationId: number
+  affiliationId: number,
 ): Promise<Review[]> {
   try {
     const reviewsData = await prisma.$queryRaw<Review[]>`

--- a/actions/review.action.ts
+++ b/actions/review.action.ts
@@ -49,7 +49,13 @@ export async function fetchReview(reviewId: string) {
 
 export async function getReview(reviewId: number) {
   try {
-    const review = await fetch(`api/review/get/${reviewId}`);
+    // どれが正解？
+    // const review = await fetch(`/api/review/get/${reviewId}`)
+    // const review = await fetch(`https://kanso-batake.vercel.app//api/review/get/${reviewId}`)
+    const review = await fetch(
+      `http://localhost:3000/api/review/get/${reviewId}`,
+    );
+    console.log(reviewId);
     return review;
   } catch (error) {
     console.log(error);

--- a/actions/review.action.ts
+++ b/actions/review.action.ts
@@ -128,26 +128,18 @@ export async function deleteReview(
 }
 */
 
-export async function deleteReview(reviewData: Review, userId: string) {
+export async function deleteReview(reviewId: number) {
   try {
-    await prisma.$executeRaw<Review[]>`
-    DELETE FROM "Reviews"
-    WHERE id = ${reviewData.id};`;
-
-    //わからん。
-    /*
-  try {
-    await Promise.all([deleteImage(reviewData.id.toString()), prismaQuery]);
-  } catch (error) {
-    console.log(error);
-    throw new Error("Failed to delete review.");
-  }*/
+    // どれが正解？
+    // ブランチをマージしたらコメントを外し正しいエンドポイントを指定する
+    // const review = await fetch(`/api/review/${reviewId}`)
+    // const review = await fetch(`https://kanso-batake.vercel.app/api/review/${reviewId}`)
+    const res = await fetch(`http://localhost:3000/api/review/${reviewId}`, {
+      method: "DELETE",
+    });
   } catch (error) {
     throw new Error("failed to delete review.");
   }
-
-  revalidatePath(`/user/${userId}`);
-  redirect(`/user/${userId}`);
 }
 
 /*

--- a/app/(home)/edit/[reviewId]/page.tsx
+++ b/app/(home)/edit/[reviewId]/page.tsx
@@ -1,7 +1,7 @@
 import { fetchUser } from "@/actions/user.action";
 import { ReviewForm } from "@/components/form/ReviewForm";
 import { currentUser } from "@clerk/nextjs";
-import { fetchReview } from "@/actions/review.action";
+import { getReview } from "@/actions/review.action";
 import React from "react";
 import { redirect } from "next/navigation";
 
@@ -13,7 +13,7 @@ const page = async ({
   const user = await currentUser();
   if (!user) return null;
   const userInfo = (await fetchUser(user.id))[0];
-  const review = (await fetchReview(Number(reviewId)))[0];
+  const review = await getReview(Number(reviewId));
 
   if (userInfo.id !== review.user_id) redirect("/");
 

--- a/app/(home)/review/[reviewId]/page.tsx
+++ b/app/(home)/review/[reviewId]/page.tsx
@@ -14,7 +14,6 @@ const page = async ({
   const _user = await currentUser();
   if (!_user) return null;
 
-  const reviewData = await getReview(Number(reviewId));
   return (
     <div className="flex flex-col gap-5">
       {/* <Review reviewData={reviewData} clamp={false} userId={_user.id} /> */}

--- a/app/(home)/review/[reviewId]/page.tsx
+++ b/app/(home)/review/[reviewId]/page.tsx
@@ -1,22 +1,25 @@
 import React from "react";
 import Review from "@/components/Review";
-import { fetchReview } from "@/actions/review.action";
+import { getReview } from "@/actions/review.action";
 import { currentUser } from "@clerk/nextjs";
 import { CommentForm } from "@/components/review/CommentForm";
 import CommentList from "@/components/review/CommentList";
+import ReviewContainer from "@/components/ReviewContainer";
 
 const page = async ({
   params: { reviewId },
 }: {
-  params: { reviewId: string };
+  params: { reviewId: number };
 }) => {
   const _user = await currentUser();
   if (!_user) return null;
 
-  const reviewData = (await fetchReview(Number(reviewId)))[0];
+  const reviewData = await getReview(Number(reviewId));
   return (
     <div className="flex flex-col gap-5">
-      <Review reviewData={reviewData} clamp={false} userId={_user.id} />
+      {/* <Review reviewData={reviewData} clamp={false} userId={_user.id} /> */}
+      {/* ReviewContainerでReviewを呼ぶ */}
+      <ReviewContainer key={reviewId} reviewId={reviewId} clamp={true} />
       <CommentForm userId={_user.id} reviewId={Number(reviewId)} />
       <CommentList reviewId={Number(reviewId)} />
     </div>

--- a/components/ReviewAction.tsx
+++ b/components/ReviewAction.tsx
@@ -28,7 +28,7 @@ const ReviewAction = ({ reviewData, userId }: Props) => {
   if (!userId || !reviewData) return null;
 
   const deleteButtonClickHandler = async () => {
-    await deleteReview(reviewData, userId);
+    await deleteReview(reviewData.id);
   };
 
   return (

--- a/components/ReviewContainer.tsx
+++ b/components/ReviewContainer.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Review from "./Review";
-import { fetchReview } from "@/actions/review.action";
+import { getReview } from "@/actions/review.action";
 import { fetchUser } from "@/actions/user.action";
 
 type Props = {
@@ -11,12 +11,12 @@ type Props = {
 const ReviewContainer = async ({ reviewId, clamp }: Props) => {
   if (!reviewId) return null;
 
-  const reviewData = await fetchReview(reviewId);
-  const userInfo = await fetchUser(reviewData[0].user_id);
+  const reviewData = await getReview(reviewId);
+  const userInfo = await fetchUser(reviewData.user_id);
 
   return (
     <>
-      <Review reviewData={reviewData[0]} userInfo={userInfo[0]} clamp={clamp} />
+      <Review reviewData={reviewData} userInfo={userInfo[0]} clamp={clamp} />
     </>
   );
 };

--- a/components/form/ReviewForm/index.tsx
+++ b/components/form/ReviewForm/index.tsx
@@ -50,7 +50,7 @@ export const ReviewForm = ({ review, user, mode = "create" }: Props) => {
   const [step, setStep] = useState<number>(MIN_STEP);
   const [files, setFiles] = useState<File[]>([]);
   const currentLabel = multiStepFormNavItemList.find(
-    (item) => item.step === step
+    (item) => item.step === step,
   )?.label;
 
   const form = useForm<z.infer<typeof FormSchema>>({
@@ -120,7 +120,7 @@ export const ReviewForm = ({ review, user, mode = "create" }: Props) => {
       if (mode === "create") {
         await setReview(user.id, reviewData);
       } else if (mode === "edit") {
-        await updateReview(user.id, reviewData);
+        await updateReview(reviewData);
       }
     } catch (error) {
       console.log(error);

--- a/components/form/ReviewForm/index.tsx
+++ b/components/form/ReviewForm/index.tsx
@@ -16,6 +16,7 @@ import { setReview, updateReview } from "@/actions/review.action";
 import { Button } from "@/components/ui/button";
 import MultiStepFormNavBar from "../MultiStepFormNavBar";
 import { Review, User } from "@/type";
+import { useRouter } from "next/navigation";
 
 type Props = {
   user?: User;
@@ -52,6 +53,7 @@ export const ReviewForm = ({ review, user, mode = "create" }: Props) => {
   const currentLabel = multiStepFormNavItemList.find(
     (item) => item.step === step,
   )?.label;
+  const router = useRouter();
 
   const form = useForm<z.infer<typeof FormSchema>>({
     resolver: zodResolver(FormSchema),
@@ -125,6 +127,8 @@ export const ReviewForm = ({ review, user, mode = "create" }: Props) => {
     } catch (error) {
       console.log(error);
     }
+
+    router.back();
   }
 
   return (


### PR DESCRIPTION
# 概要
- レビュー操作の再実装：APIを使ってレビューをGET・UPDATE・Deleteする(レビュー投稿以外)
# やったこと
- getReviewを作成し、`/api/review/get/[id]`をたたく。
  - 今まで`fetchReview`で直接データベースをたたいていた場所をgetReviewに更新した。
- updateReviewを更新し、`/api/review/[id]`をPUTメソッドでたたく。
- deleteReviewを更新し、`/api/review/[id]`をDELETEメソッドでたたく。
- ReviewFormでレビューの投稿や編集を行った後に、ひとつ前のページに戻るように変更。 
# 特にレビューしてほしいところ
- getReviewでＡＰＩをたたく側の実装
  - URIに相対パス(`/api/review/get/[id]`)をたたくとAPIからエラーが返ってくる
  - 逆に絶対パス(`http://localhost:3000/api/review/get/${reviewId}`)なら通る
# 保留していること
- APIのレスポンスが、Response型になっていてReview型じゃないのでレビューを取得した後のプログラムが動かないのはどうしたらよいんだろうか
  - 受け取る側がReview型として受け取る？APIサーバ側がReview型として返す？
# 動作確認
- URIを絶対パスで指定すれば動作することを確認
- ただ取得したデータの型がわからず表示はできてない