### PR TITLE
ハンバーガーメニューが適切に表示されるように修正

### DIFF
--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -24,13 +24,13 @@ const Header = async () => {
           href="/"
           className={clsx(
             kaisei.className,
-            "text-2xl flex flex-row items-center justify-center"
+            "text-2xl flex flex-row items-center justify-center",
           )}
         >
           <Image src="/appicon.png" width={50} height={50} alt="logo" />
           感想畑
         </Link>
-        <HeaderContents user={user} affiliation={affiliation} />
+        <HeaderContents userData={user} affiliationData={affiliation} />
       </div>
     </header>
   );


### PR DESCRIPTION
# 概要
ヘッダーでヘッダーコンテンツ呼び出し時の引数を修正　#28 の修正
# やったこと
- Headerで呼び出しているHeaderContentsの引数が`user, affiliation`になっていたので、`userData, AffiliationData`に修正
# 特にレビューしてほしいところ
特になし
# 保留していること
なし
# 動作確認
確認済み