### PR TITLE
review型の再定義

### DIFF
--- a/components/Review.tsx
+++ b/components/Review.tsx
@@ -14,13 +14,12 @@ import ReviewAction from "./ReviewAction";
 
 type Props = {
   reviewData?: ReviewType;
-  userInfo?: User;
+  userId?: string;
   clamp?: boolean;
 };
 
-const Review = ({ reviewData, userInfo, clamp }: Props) => {
+const Review = ({ reviewData, userId, clamp }: Props) => {
   if (!reviewData) return null;
-  if (!userInfo) return null;
 
   return (
     <Card>
@@ -33,14 +32,14 @@ const Review = ({ reviewData, userInfo, clamp }: Props) => {
         <PaperData paperData={reviewData.paper_data} />
         <Separator />
       </CardHeader>
-      <ReviewTags reviewId={reviewData.id} />
-      <ReviewUserInfo userInfo={userInfo} />
+      <ReviewTags tagsData={reviewData.tags} />
+      <ReviewUserInfo userInfo={reviewData.user_info} />
       {reviewData.thumbnail_url && (
         <CardContent>
           <Modal imageUrl={reviewData.thumbnail_url} />
         </CardContent>
       )}
-      <ReviewAction userId={userInfo.id} reviewData={reviewData} />
+      <ReviewAction userId={userId} reviewData={reviewData} />
       <CardContent className="markdown">
         <ReactMarkDown
           className={clsx(clamp ? "line-clamp-4" : "")}

--- a/components/ReviewAction.tsx
+++ b/components/ReviewAction.tsx
@@ -33,15 +33,15 @@ const ReviewAction = ({ reviewData, userId }: Props) => {
 
   return (
     <CardContent>
-      {userId === reviewData.user_id && (
+      {userId === reviewData.user_info.id && (
         <div className="flex flex-row gap-2 py-3">
-          {userId == reviewData.user_id && (
+          {userId == reviewData.user_info.id && (
             <a href={`/edit/${reviewData.id}`} target="">
               <FaRegEdit size="2rem" />
             </a>
           )}
 
-          {userId === reviewData.user_id && (
+          {userId === reviewData.user_info.id && (
             <>
               <AlertDialog>
                 <AlertDialogTrigger asChild>

--- a/components/ReviewContainer.tsx
+++ b/components/ReviewContainer.tsx
@@ -12,11 +12,10 @@ const ReviewContainer = async ({ reviewId, clamp }: Props) => {
   if (!reviewId) return null;
 
   const reviewData = await fetchReview(reviewId);
-  const userInfo = await fetchUser(reviewData[0].user_id);
 
   return (
     <>
-      <Review reviewData={reviewData[0]} userInfo={userInfo[0]} clamp={clamp} />
+      <Review reviewData={reviewData[0]} clamp={clamp} />
     </>
   );
 };

--- a/components/ReviewTags.tsx
+++ b/components/ReviewTags.tsx
@@ -1,16 +1,15 @@
-import { fetchTagsByReviewId } from "@/actions/tag.action";
 import React from "react";
 import { CardContent } from "./ui/card";
 import Link from "next/link";
+import { Tag } from "@/type";
 
 type Props = {
-  reviewId?: number;
+  tagsData?: Tag[];
 };
 
-const ReviewTags = async ({ reviewId }: Props) => {
-  if (!reviewId) return null;
+const ReviewTags = ({ tagsData }: Props) => {
+  if (!tagsData) return null;
 
-  const tagsData = await fetchTagsByReviewId(reviewId);
   return (
     <>
       <CardContent className="flex gap-2">

--- a/components/lab/MyLabReviews.tsx
+++ b/components/lab/MyLabReviews.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import Review from "../Review";
 import { fetchReviewsByAffiliationId } from "@/actions/review.action";
 import { Review as ReviewType } from "@/type";
-import ReviewContainer from "../ReviewContainer";
 
 type Props = {
   affiliationId?: number;
@@ -20,9 +19,6 @@ const MyLabReviews = async ({ affiliationId, tag }: Props) => {
     return <div>No Reviews.</div>;
   }
 
-  const reviewIds = reviewsData.map((review) => review.id);
-  // const reviewIds = await fetchReviewIdsByAffiliationId(tag);
-
   return (
     <>
       {tag ? (
@@ -31,10 +27,8 @@ const MyLabReviews = async ({ affiliationId, tag }: Props) => {
         </div>
       ) : null}
       <div className="flex flex-col gap-2">
-        {reviewIds.map((reviewId) => {
-          return (
-            <ReviewContainer key={reviewId} reviewId={reviewId} clamp={true} />
-          );
+        {reviewsData.map((review) => {
+          return <Review key={review.id} reviewData={review} clamp={true} />;
         })}
       </div>
     </>

--- a/components/top/Reviews.tsx
+++ b/components/top/Reviews.tsx
@@ -1,6 +1,6 @@
 import { fetchReviewsByFilter } from "@/actions/review.action";
 import React from "react";
-import ReviewContainer from "../ReviewContainer";
+import Review from "../Review";
 
 type Props = {
   tag?: string;
@@ -8,8 +8,6 @@ type Props = {
 
 const Reviews = async ({ tag }: Props) => {
   const reviewsData = await fetchReviewsByFilter(tag);
-  const reviewIds = reviewsData.map((review) => review.id);
-  // const reviewIds = await fetchReviewIdsByFilter(tag);
 
   return (
     <>
@@ -19,10 +17,8 @@ const Reviews = async ({ tag }: Props) => {
         </div>
       ) : null}
       <div className="flex flex-col gap-2">
-        {reviewIds.map((reviewId) => {
-          return (
-            <ReviewContainer key={reviewId} reviewId={reviewId} clamp={true} />
-          );
+        {reviewsData.map((review) => {
+          return <Review key={review.id} reviewData={review} clamp={true} />;
         })}
       </div>
     </>

--- a/components/user/ReviewsByUser.tsx
+++ b/components/user/ReviewsByUser.tsx
@@ -29,14 +29,7 @@ const ReviewsByUser = async ({ userId, tag }: Props) => {
       )}
       <div className="flex flex-col gap-2">
         {reviewsData.map((review) => {
-          return (
-            <Review
-              key={review.id}
-              reviewData={review}
-              userInfo={userInfo[0]}
-              clamp={true}
-            />
-          );
+          return <Review key={review.id} reviewData={review} clamp={true} />;
         })}
       </div>
     </>

--- a/type/index.ts
+++ b/type/index.ts
@@ -46,7 +46,7 @@ export type Review = {
   content: string | null;
   paper_title: string;
   paper_data: Paper;
-  user_id: string;
+  user_info: User;
   comments: Comment[];
   tags: Tag[];
   created_at: string | Date;


### PR DESCRIPTION
# 概要
もともとのReview型だとコンポーネント設計に影響があった。
また、APIへの無駄なリクエストが生じる設計になっていた。

# やったこと
Review型がuser_idを持つのではなく、User型のuser_infoを持つようにした。

# 動作確認
Preview以外は済(別ブランチで作業するため)