### PR TITLE
Onboardingのエラーを解消　#27

### DIFF
--- a/actions/affiliation.action.ts
+++ b/actions/affiliation.action.ts
@@ -1,11 +1,11 @@
 "use server";
 
-import { affiliationInterface } from "@/constants";
+import { Affiliation } from "@/type";
 import { prisma } from "@/lib/prisma/prisma-client";
 
-export async function fetchAllAffiliations(): Promise<affiliationInterface[]> {
+export async function fetchAllAffiliations(): Promise<Affiliation[]> {
   try {
-    const affiliationsData = await prisma.$queryRaw<affiliationInterface[]>`
+    const affiliationsData = await prisma.$queryRaw<Affiliation[]>`
         SELECT * FROM "Affiliations"`;
 
     return affiliationsData;
@@ -17,9 +17,9 @@ export async function fetchAllAffiliations(): Promise<affiliationInterface[]> {
 
 export async function fetchAffiliation(
   affiliationId: number,
-): Promise<affiliationInterface[]> {
+): Promise<Affiliation[]> {
   try {
-    const affiliationsData = await prisma.$queryRaw<affiliationInterface[]>`
+    const affiliationsData = await prisma.$queryRaw<Affiliation[]>`
         SELECT * FROM "Affiliations" WHERE id = ${affiliationId}`;
 
     return affiliationsData;
@@ -31,9 +31,9 @@ export async function fetchAffiliation(
 
 export async function fetchAffiliationsByUserId(
   userId: string,
-): Promise<affiliationInterface[]> {
+): Promise<Affiliation[]> {
   try {
-    const affiliationsData = await prisma.$queryRaw<affiliationInterface[]>`
+    const affiliationsData = await prisma.$queryRaw<Affiliation[]>`
         SELECT "Affiliations".*
         FROM "Affiliations"
         JOIN "_AffiliationsToUsers" ON "Affiliations".id = "_AffiliationsToUsers".affiliation_id
@@ -51,11 +51,11 @@ export async function fetchAffiliationIdByAffiliationName(
   AffiliationName: string,
 ): Promise<number> {
   try {
-    const affiliationId = await prisma.$queryRaw<number>`
+    const affiliationId = await prisma.$queryRaw<{ id: number }[]>`
       SELECT "id"
       FROM "Affiliations"
       WHERE name = ${AffiliationName};`;
-    if (affiliationId == 0) {
+    if (!affiliationId) {
       return 0;
     }
     return affiliationId[0].id;

--- a/actions/affiliation.action.ts
+++ b/actions/affiliation.action.ts
@@ -58,14 +58,14 @@ export async function fetchAffiliationIdByAffiliationName(
     if (affiliationId == 0) {
       return 0;
     }
-    return affiliationId;
+    return affiliationId[0].id;
   } catch (error) {
     console.log(error);
     throw new Error("Failed to fetch affiliation id.");
   }
 }
 
-export async function setAffiliation(affiliationData: affiliationInterface) {
+export async function setAffiliation(affiliationData: Affiliation) {
   try {
     await prisma.$executeRaw<number>`
       INSERT INTO "Affiliations" (name)

--- a/actions/field.action.ts
+++ b/actions/field.action.ts
@@ -35,14 +35,14 @@ export async function fetchFieldIdByFieldName(
   fieldName: string,
 ): Promise<number> {
   try {
-    const fieldId = await prisma.$queryRaw<number>`
+    const fieldId = await prisma.$queryRaw<{ id: number }[]>`
       SELECT "id"
       FROM "Fields"
       WHERE name = ${fieldName};`;
-    if (fieldId == 0) {
+    if (!fieldId) {
       return 0;
     }
-    return fieldId;
+    return fieldId[0].id;
   } catch (error) {
     console.log(error);
     throw new Error("Failed to fetch field id.");

--- a/actions/field.action.ts
+++ b/actions/field.action.ts
@@ -1,11 +1,11 @@
 "use server";
 
-import { fieldInterface } from "@/constants";
+import { Field } from "@/type";
 import { prisma } from "@/lib/prisma/prisma-client";
 
-export async function fetchAllFields(): Promise<fieldInterface[]> {
+export async function fetchAllFields(): Promise<Field[]> {
   try {
-    const fieldsData = await prisma.$queryRaw<fieldInterface[]>`
+    const fieldsData = await prisma.$queryRaw<Field[]>`
         SELECT * FROM "Fields"`;
 
     return fieldsData;
@@ -14,11 +14,9 @@ export async function fetchAllFields(): Promise<fieldInterface[]> {
   }
 }
 
-export async function fetchFieldsByUserId(
-  userId: string,
-): Promise<fieldInterface[]> {
+export async function fetchFieldsByUserId(userId: string): Promise<Field[]> {
   try {
-    const affiliationsData = await prisma.$queryRaw<fieldInterface[]>`
+    const affiliationsData = await prisma.$queryRaw<Field[]>`
         SELECT "Fields".*
         FROM "Fields"
         JOIN "_FieldsToUsers" ON "Fields".id = "_FieldsToUsers".field_id
@@ -49,7 +47,7 @@ export async function fetchFieldIdByFieldName(
   }
 }
 
-export async function setField(fieldData: fieldInterface) {
+export async function setField(fieldData: Field) {
   try {
     await prisma.$executeRaw<number>`
       INSERT INTO "Fields" (name)


### PR DESCRIPTION
# 概要
Onboardingのエラーを解消　#27
# やったこと
- `fetchAffiliationIdByAffiliationName()`と`fetchFieldIdByFieldName()`のクエリに対する戻り値の型指定を正しく修正
- それにより`setAffiliation()`,`setField()`したときのエラーを解消
# 特にレビューしてほしいところ
- とくにはなし
# 保留していること
- なし
# 動作確認
- Good!
  - 新しくOnboadingすると、Userテーブル、Affiliationテーブル、Fieldsテーブルに正しくユーザ情報が登録されていることが確認できる。
  - すでにユーザ登録をしていてTestできない場合は、Userテーブルから自分の行を削除すれば新しくOnboardingできるようになる(`/onboading`から)