### PR TITLE
User情報登録時にDBに存在しない所属・分野を入力するとエラーになるバグを修正

### DIFF
--- a/actions/affiliation.action.ts
+++ b/actions/affiliation.action.ts
@@ -55,7 +55,8 @@ export async function fetchAffiliationIdByAffiliationName(
       SELECT "id"
       FROM "Affiliations"
       WHERE name = ${AffiliationName};`;
-    if (!affiliationId) {
+    console.log(affiliationId);
+    if (!affiliationId.length) {
       return 0;
     }
     return affiliationId[0].id;

--- a/actions/field.action.ts
+++ b/actions/field.action.ts
@@ -37,7 +37,7 @@ export async function fetchFieldIdByFieldName(
       SELECT "id"
       FROM "Fields"
       WHERE name = ${fieldName};`;
-    if (!fieldId) {
+    if (!fieldId.length) {
       return 0;
     }
     return fieldId[0].id;


### PR DESCRIPTION
# 概要
- #37 の修正
- User情報登録時にDBに存在しない所属・分野を入力するとエラーになるバグを修正した
# やったこと
- DBへのクエリの戻り値の空配列判定が間違っていたので修正
# 特にレビューしてほしいところ
- とくになし
# 保留していること
- とくになし
# 動作確認
- できた！