### PR TITLE
レビュー一覧をGET APIを叩いて取得できる

### DIFF
--- a/actions/review.action.ts
+++ b/actions/review.action.ts
@@ -33,45 +33,21 @@ export async function fetchAllReviews(): Promise<Review[]> {
   }
 }
 
-/*
-export async function fetchReview(reviewId: string) {
+export async function fetchReview(reviewId: number): Promise<Review> {
   try {
-    const reviewData = await getDoc(doc(db, `reviews/${reviewId}`));
-    if (reviewData.exists()) {
-      return reviewData.data() as reviewInterface;
-    } else {
-      throw new Error("Failed to fetch review.");
-    }
-  } catch (error) {
-    console.log(error);
-    throw new Error("Failed to fetch review.");
-  }
-}
-*/
-
-export async function fetchReview(reviewId: number): Promise<Review[]> {
-  try {
-    const reviewData = await prisma.$queryRaw<Review[]>`
-        SELECT * FROM "Reviews" WHERE id = ${reviewId};`;
-
+    const response = await fetch(
+      `http://localhost:3000/api/reviews/${reviewId}`,
+      {
+        method: "GET",
+      },
+    );
+    const reviewData: Review = await response.json();
     return reviewData;
   } catch (error) {
     console.log(error);
     throw new Error("Failed to fetch review.");
   }
 }
-
-/*
-export async function setReview(userId: string, reviewData: reviewInterface) {
-  await Promise.all([
-    setDoc(doc(db, `reviews/${reviewData.id}`), reviewData),
-    setDoc(doc(db, `users/${userId}/reviews/${reviewData.id}`), reviewData),
-  ]);
-
-  revalidatePath("/create");
-  redirect("/");
-}
-*/
 
 export async function setReview(reviewData: Review) {
   try {

--- a/actions/review.action.ts
+++ b/actions/review.action.ts
@@ -7,31 +7,18 @@ import { redirect } from "next/navigation";
 import { deleteImage } from "./image.action";
 import { prisma } from "@/lib/prisma/prisma-client";
 
-/*
-export async function getAllReviews() {
-  const col = query(collection(db, "reviews"), orderBy("id", "desc"));
-
-  let result: reviewInterface[] = [];
-  const allReviewsSnapshot = await getDocs(col);
-  allReviewsSnapshot.forEach((doc) => {
-    result.push(doc.data() as reviewInterface);
-  });
-
-  return result;
-}
-*/
-
-export async function fetchAllReviews(): Promise<Review[]> {
-  try {
-    const reviewsData = await prisma.$queryRaw<Review[]>`
-        SELECT * FROM "Reviews" ORDER BY created_at DESC`;
-
-    return reviewsData;
-  } catch (error) {
-    console.log(error);
-    throw new Error("Failed to fetch reviews.");
-  }
-}
+// export async function fetchAllReviews(): Promise<Review[]> {
+//   try {
+//     const response = await fetch(`http://localhost:3000/api/reviews/`, {
+//       method: "GET",
+//     });
+//     const reviewData: Review[] = await response.json();
+//     return reviewData;
+//   } catch (error) {
+//     console.log(error);
+//     throw new Error("Failed to fetch reviews.");
+//   }
+// }
 
 export async function fetchReview(reviewId: number): Promise<Review> {
   try {
@@ -64,21 +51,6 @@ export async function setReview(reviewData: Review) {
     throw new Error("Failed to set review.");
   }
 }
-
-/*
-export async function updateReview(
-  userId: string,
-  reviewData: reviewInterface
-) {
-  await Promise.all([
-    updateDoc(doc(db, `reviews/${reviewData.id}`), reviewData),
-    updateDoc(doc(db, `users/${userId}/reviews/${reviewData.id}`), reviewData),
-  ]);
-
-  revalidatePath(`/user/${userId}`);
-  redirect(`/user/${userId}`);
-}
-*/
 
 export async function updateReview(userId: string, reviewData: Review) {
   try {
@@ -133,145 +105,22 @@ export async function deleteReview(reviewData: Review, userId: string) {
   redirect(`/user/${userId}`);
 }
 
-/*
-export async function fetchReviewsByUser(userId: string) {
-  const col = query(
-    collection(db, `users/${userId}/reviews`),
-    orderBy("id", "desc")
-  );
-
-  let result: reviewInterface[] = [];
-
-  try {
-    const allReviewsSnapshot = await getDocs(col);
-    allReviewsSnapshot.forEach((doc) => {
-      result.push(doc.data() as reviewInterface);
-    });
-
-    return result;
-  } catch (error) {
-    console.log(error);
-    throw new Error("Failed to fetch reviews.");
-  }
-}
-*/
-
-export async function fetchReviewsByUser(userId: string): Promise<Review[]> {
-  try {
-    const reviewsData = await prisma.$queryRaw<Review[]>`
-      SELECT *
-      FROM "Reviews"
-      WHERE user_id = ${userId}
-      ORDER BY created_at DESC;`;
-
-    return reviewsData;
-  } catch (error) {
-    console.log(error);
-    throw new Error("Failed to fecth reviews.");
-  }
-}
-
-/*
-export async function fetchReviewsByTag(searchTag: string) {
-  const col = query(
-    collection(db, "reviews"),
-    where("tags", "array-contains", searchTag)
-  );
-  let result: reviewInterface[] = [];
-  try {
-    const allReviewsSnapshot = await getDocs(col);
-    allReviewsSnapshot.forEach((doc) => {
-      result.push(doc.data() as reviewInterface);
-    });
-
-    return result;
-  } catch (error) {
-    console.log(error);
-    throw new Error("Failed to fetch reviews.");
-  }
-}
-*/
-
-export async function fetchReviewsByTag(searchTag: string): Promise<Review[]> {
-  try {
-    const reviewsData = await prisma.$queryRaw<Review[]>`
-      SELECT "Reviews".*
-      FROM "Reviews"
-      JOIN "_ReviewsToTags" ON "Reviews".id = "_ReviewsToTags".review_id
-      JOIN "Tags" ON "_ReviewsToTags".tag_id = "Tags".id
-      WHERE "Tags".name = ${searchTag}
-      ORDER BY "Reviews".created_at DESC;`;
-
-    return reviewsData;
-  } catch (error) {
-    console.log(error);
-    throw new Error("Failed to fecth reviews.");
-  }
-}
-
-/*
-export async function fetchReviewsByTagAndUser(
-  searchTag: string,
-  userId: string
-) {
-  const col = query(
-    collection(db, `users/${userId}/reviews`),
-    where("tags", "array-contains", searchTag)
-  );
-  let result: reviewInterface[] = [];
-  try {
-    const allReviewsSnapshot = await getDocs(col);
-    allReviewsSnapshot.forEach((doc) => {
-      result.push(doc.data() as reviewInterface);
-    });
-
-    return result;
-  } catch (error) {
-    console.log(error);
-    throw new Error("Failed to fetch reviews.");
-  }
-}
-*/
-
-export async function fetchReviewsByTagAndUser(
-  searchTag: string,
-  userId: string,
-): Promise<Review[]> {
-  try {
-    const reviewsData = await prisma.$queryRaw<Review[]>`
-      SELECT "Reviews".*
-      FROM "Reviews"
-      JOIN "_ReviewsToTags" ON "Reviews".id = "_ReviewsToTags".review_id
-      JOIN "Tags" ON "_ReviewsToTags".tag_id = "Tags".id
-      WHERE "Tags".name = ${searchTag}
-      AND "Reviews".user_id = ${userId}
-      ORDER BY "Reviews".created_at DESC;`;
-
-    return reviewsData;
-  } catch (error) {
-    console.log(error);
-    throw new Error("Failed to fecth reviews.");
-  }
-}
-
 export async function fetchReviewsByFilter(
   searchTag?: string,
   userId?: string,
 ): Promise<Review[]> {
   try {
-    if (!searchTag && !userId) {
-      return fetchAllReviews();
-    } else if (!searchTag && userId) {
-      return fetchReviewsByUser(userId);
-    } else if (searchTag && !userId) {
-      return fetchReviewsByTag(searchTag);
-    } else if (searchTag && !userId) {
-      return fetchReviewsByTag(searchTag);
-    } else if (searchTag && userId) {
-      return fetchReviewsByTagAndUser(searchTag, userId);
-    } else {
-      return [];
-    }
+    const uriTag = searchTag ? `searchTag=${searchTag}&` : ``;
+    const uriId = userId ? `userId=${userId}` : ``;
+    console.log(`http://localhost:3000/api/reviews?` + uriTag + uriId);
+    const response = await fetch(
+      `http://localhost:3000/api/reviews?` + uriTag + uriId,
+      {
+        method: "GET",
+      },
+    );
+    const reviewData: Review[] = await response.json();
+    return reviewData;
   } catch (error) {
     console.log(error);
     throw new Error("Failed to fetch reviews.");
@@ -298,19 +147,3 @@ export async function fetchReviewsByAffiliationId(
     throw new Error("Failed to fetch reviews.");
   }
 }
-
-/*
-
-こういう汎用的な関数は今後使わなくなるはず
-
-export async function fetchReviewsByUserIds(userIds: string[], tag?: string) {
-  try {
-    const promises = userIds.map((userId) => fetchReviewsByFilter(tag, userId));
-    const reviews = await Promise.all(promises);
-    return reviews.flat().sort();
-  } catch (error) {
-    console.log(error);
-    throw new Error("Failed to fetch reviews.");
-  }
-}
-*/

--- a/actions/review.action.ts
+++ b/actions/review.action.ts
@@ -112,7 +112,6 @@ export async function fetchReviewsByFilter(
   try {
     const uriTag = searchTag ? `searchTag=${searchTag}&` : ``;
     const uriId = userId ? `userId=${userId}` : ``;
-    console.log(`http://localhost:3000/api/reviews?` + uriTag + uriId);
     const response = await fetch(
       `http://localhost:3000/api/reviews?` + uriTag + uriId,
       {

--- a/app/(home)/edit/[reviewId]/page.tsx
+++ b/app/(home)/edit/[reviewId]/page.tsx
@@ -13,9 +13,9 @@ const page = async ({
   const user = await currentUser();
   if (!user) return null;
   const userInfo = (await fetchUser(user.id))[0];
-  const review = (await fetchReview(Number(reviewId)))[0];
+  const review = await fetchReview(Number(reviewId));
 
-  if (userInfo.id !== review.user_id) redirect("/");
+  if (userInfo.id !== review.user_info.id) redirect("/");
 
   return (
     <div className="w-full">

--- a/app/(home)/review/[reviewId]/page.tsx
+++ b/app/(home)/review/[reviewId]/page.tsx
@@ -13,7 +13,7 @@ const page = async ({
   const _user = await currentUser();
   if (!_user) return null;
 
-  const reviewData = (await fetchReview(Number(reviewId)))[0];
+  const reviewData = await fetchReview(Number(reviewId));
   return (
     <div className="flex flex-col gap-5">
       <Review reviewData={reviewData} clamp={false} userId={_user.id} />

--- a/app/api/reviews/[id]/route.ts
+++ b/app/api/reviews/[id]/route.ts
@@ -1,16 +1,60 @@
 import { NextRequest, NextResponse } from "next/server";
-import { Review } from "@/type";
+import { Paper, Review } from "@/type";
 import { prisma } from "@/lib/prisma/prisma-client";
+import { Reviews, Users, Tags, Comments } from "@prisma/client";
 
-async function fetchReview(reviewId: number): Promise<Review | null> {
+async function fetchReview(reviewId: number): Promise<Reviews[]> {
   try {
-    const review: Review | null = await prisma.$queryRaw<Review[]>`
-    SELECT * FROM "Reviews" WHERE id = ${reviewId};
-    `.then((result) => result[0] || null);
+    const review = await prisma.$queryRaw<Reviews[]>`
+      SELECT * FROM "Reviews" WHERE id = ${reviewId};
+    `;
     return review;
   } catch (error) {
     console.error(error);
     throw new Error("Failed to fetch reviews.");
+  }
+}
+
+async function fetchTagsByReviewId(reviewId: number): Promise<Tags[]> {
+  try {
+    const tags = await prisma.$queryRaw<Tags[]>`
+        SELECT "Tags".*
+        FROM "Tags"
+        JOIN "_ReviewsToTags" ON "Tags".id = "_ReviewsToTags".tag_id
+        JOIN "Reviews" ON "_ReviewsToTags".review_id = "Reviews".id
+        WHERE "Reviews".id = ${reviewId};`;
+    return tags;
+  } catch (error) {
+    console.log(error);
+    throw new Error("Failed to fetch tags.");
+  }
+}
+
+async function fetchCommentsByReviewId(reviewId: number): Promise<Comments[]> {
+  try {
+    const comments = await prisma.$queryRaw<Comments[]>`
+        SELECT "Comments".*
+        FROM "Comments"
+        JOIN "_ReviewsToComments" ON "Comments".id = "_ReviewsToComments".comment_id
+        JOIN "Reviews" ON "_ReviewsToComments".review_id = "Reviews".id
+        WHERE "Reviews".id = ${reviewId};`;
+
+    return comments;
+  } catch (error) {
+    console.log(error);
+    throw new Error("Failed to fetch comments.");
+  }
+}
+
+async function fetchUser(userId: string): Promise<Users[]> {
+  try {
+    const userData = await prisma.$queryRaw<Users[]>`
+        SELECT * FROM "Users" WHERE id = ${userId};`;
+
+    return userData;
+  } catch (error) {
+    console.log(error);
+    throw new Error("Failed to fetch user.");
   }
 }
 
@@ -19,16 +63,38 @@ export async function GET(
   { params }: { params: { id: string } },
 ): Promise<NextResponse> {
   try {
+    // ReviewIdをnumberに変換
     const reviewId = parseInt(params.id);
     if (isNaN(reviewId)) {
       return NextResponse.json({ error: "Invalid review ID" }, { status: 400 });
     }
 
+    // reviewsテーブルからreviewsを取得
     const review = await fetchReview(reviewId);
-    if (!review) {
+    if (!review.length) {
       return NextResponse.json({ error: "Invalid review ID" }, { status: 400 });
     }
-    return NextResponse.json(review, { status: 200 });
+    // Tagsテーブルから該当するタグをすべて取得
+    const tags = await fetchTagsByReviewId(reviewId);
+
+    // Usersテーブルからレビューの筆者を取得
+    const user = await fetchUser(review[0].user_id);
+
+    // Commentsテーブルからレビューの筆者を取得
+    const comments = await fetchCommentsByReviewId(review[0].id);
+
+    const reviewData: Review = {
+      id: reviewId,
+      content: review[0].content,
+      paper_title: review[0].paper_title,
+      paper_data: review[0].paper_data as Paper,
+      user_info: user[0],
+      comments: comments,
+      tags: tags,
+      created_at: review[0].created_at,
+      thumbnail_url: review[0].thumbnail_url,
+    };
+    return NextResponse.json(reviewData, { status: 200 });
   } catch (error) {
     console.error(error);
     return NextResponse.json(

--- a/app/api/reviews/[id]/route.ts
+++ b/app/api/reviews/[id]/route.ts
@@ -68,7 +68,6 @@ export async function GET(
     if (isNaN(reviewId)) {
       return NextResponse.json({ error: "Invalid review ID" }, { status: 400 });
     }
-
     // reviewsテーブルからreviewsを取得
     const review = await fetchReview(reviewId);
     if (!review.length) {
@@ -76,13 +75,11 @@ export async function GET(
     }
     // Tagsテーブルから該当するタグをすべて取得
     const tags = await fetchTagsByReviewId(reviewId);
-
     // Usersテーブルからレビューの筆者を取得
     const user = await fetchUser(review[0].user_id);
-
     // Commentsテーブルからレビューの筆者を取得
     const comments = await fetchCommentsByReviewId(review[0].id);
-
+    // Review型を構成
     const reviewData: Review = {
       id: reviewId,
       content: review[0].content,

--- a/app/api/reviews/route.ts
+++ b/app/api/reviews/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
-import { Review, Tag } from "@/type";
+import { Paper, Review, Tag } from "@/type";
 import { prisma } from "@/lib/prisma/prisma-client";
+import { Reviews, Users, Tags } from "@prisma/client";
 
 // fetchReviews()の作成により廃止
 // async function fetchAllReviews(): Promise<Review[]> {
@@ -18,20 +19,20 @@ import { prisma } from "@/lib/prisma/prisma-client";
 async function fetchReviews(
   tag: string | null,
   id: string | null,
-): Promise<Review[]> {
+): Promise<Reviews[]> {
   try {
-    let reviews: Review[];
+    let reviews: Reviews[];
     if (!tag && !id) {
-      reviews = await prisma.$queryRaw<Review[]>`
+      reviews = await prisma.$queryRaw<Reviews[]>`
       SELECT * FROM "Reviews" ORDER BY created_at DESC;`;
     } else if (!tag && id) {
-      reviews = await prisma.$queryRaw<Review[]>`
+      reviews = await prisma.$queryRaw<Reviews[]>`
         SELECT *
         FROM "Reviews"
         WHERE user_id = ${id}
         ORDER BY created_at DESC;`;
     } else if (tag && !id) {
-      reviews = await prisma.$queryRaw<Review[]>`
+      reviews = await prisma.$queryRaw<Reviews[]>`
         SELECT "Reviews".*
         FROM "Reviews"
         JOIN "_ReviewsToTags" ON "Reviews".id = "_ReviewsToTags".review_id
@@ -39,7 +40,7 @@ async function fetchReviews(
         WHERE "Tags".name = ${tag}
         ORDER BY "Reviews".created_at DESC;`;
     } else if (tag && id) {
-      reviews = await prisma.$queryRaw<Review[]>`
+      reviews = await prisma.$queryRaw<Reviews[]>`
         SELECT "Reviews".*
         FROM "Reviews"
         JOIN "_ReviewsToTags" ON "Reviews".id = "_ReviewsToTags".review_id
@@ -48,7 +49,7 @@ async function fetchReviews(
         AND "Reviews".user_id = ${id}
         ORDER BY "Reviews".created_at DESC;`;
     } else {
-      reviews = await prisma.$queryRaw<Review[]>`
+      reviews = await prisma.$queryRaw<Reviews[]>`
         SELECT * FROM "Reviews" ORDER BY created_at DESC;`;
     }
     return reviews;
@@ -105,6 +106,33 @@ async function setReview(reviewData: Review) {
   }
 }
 
+async function fetchTagsByReviewId(reviewId: number): Promise<Tags[]> {
+  try {
+    const tags = await prisma.$queryRaw<Tags[]>`
+        SELECT "Tags".*
+        FROM "Tags"
+        JOIN "_ReviewsToTags" ON "Tags".id = "_ReviewsToTags".tag_id
+        JOIN "Reviews" ON "_ReviewsToTags".review_id = "Reviews".id
+        WHERE "Reviews".id = ${reviewId};`;
+    return tags;
+  } catch (error) {
+    console.log(error);
+    throw new Error("Failed to fetch tags.");
+  }
+}
+
+async function fetchUser(userId: string): Promise<Users[]> {
+  try {
+    const userData = await prisma.$queryRaw<Users[]>`
+        SELECT * FROM "Users" WHERE id = ${userId};`;
+
+    return userData;
+  } catch (error) {
+    console.log(error);
+    throw new Error("Failed to fetch user.");
+  }
+}
+
 export async function GET(request: NextRequest): Promise<NextResponse> {
   const searchParams = request.nextUrl.searchParams;
   const searchTag = searchParams.get("searchTag");
@@ -113,7 +141,24 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   try {
     // const reviews = await fetchAllReviews();
     const reviews = await fetchReviews(searchTag, userId);
-    return NextResponse.json(reviews, { status: 200 });
+    const req = reviews.map(async (review) => {
+      const tags = await fetchTagsByReviewId(review.id);
+      const user = await fetchUser(review.user_id);
+      const reviewData: Review = {
+        id: review.id,
+        content: review.content,
+        paper_title: review.paper_title,
+        paper_data: review.paper_data as Paper,
+        user_info: user[0],
+        comments: [],
+        tags: tags,
+        created_at: review.created_at,
+        thumbnail_url: review.thumbnail_url,
+      };
+      return reviewData;
+    });
+    const reviewDatas = await Promise.all(req);
+    return NextResponse.json(reviewDatas, { status: 200 });
   } catch (error) {
     console.error(error);
     return NextResponse.json(

--- a/components/ReviewContainer.tsx
+++ b/components/ReviewContainer.tsx
@@ -18,7 +18,7 @@ const ReviewContainer = async ({ reviewId, clamp }: Props) => {
 
   return (
     <>
-      <Review reviewData={reviewData[0]} userId={_user.id} clamp={clamp} />
+      <Review reviewData={reviewData} userId={_user.id} clamp={clamp} />
     </>
   );
 };

--- a/components/user/ReviewsByUser.tsx
+++ b/components/user/ReviewsByUser.tsx
@@ -11,10 +11,7 @@ type Props = {
 const ReviewsByUser = async ({ userId, tag }: Props) => {
   if (!userId) return null;
 
-  const [reviewsData, userInfo] = await Promise.all([
-    fetchReviewsByFilter(tag, userId),
-    fetchUser(userId),
-  ]);
+  const [reviewsData] = await Promise.all([fetchReviewsByFilter(tag, userId)]);
 
   if (reviewsData.length === 0) {
     return <div>No Reviews.</div>;


### PR DESCRIPTION
# 概要
- レビュー一覧をGET APIを叩いて取得できる
# やったこと
- reviewIdで指定したReviewのGET APIを実装 `api/reviews/[id]` f7167e31573775d003e2ab46fc169f0b02d9f30e
- actionを更新しAPIを叩いてreviewIdで指定したReviewを取得する aa0faf186fe7a2e26516780e984a4c4a488241b3
- Review一覧のGET APIを実装 `api/reviews` 
  - クエリパラメータによって複数のSQLクエリを発行し実行する 32e19c87fddff56815d3b24b4e992c76304f80bf
- actionを更新しAPIを叩くように変更
  - `review.action.ts/fetchReviewsByFilter()`がレビュー一覧の取得を担う 277f1efb9895d2a32a4a37f540cf876d5669b3e5 30b21415809228248bab1e6855019e17d4f6773b
  - その他action関数を削除
# 特にレビューしてほしいところ
- APIのエンドポイントごとに全く同じ関数を置いてしまっている
  - (`api/reviews/`と`api/reviews/[id]`に同一の`fetchTagsByReviewId(), fetchUser()`)
  - ←なんとなくエンドポイントをまたいで使われる関数は良くない気がしたから
  - →どっちかだけ（`api/reviews`だけ）に置いておいてimport するように変更したほうが良いか？
# 保留していること
- APIのGETメソッド自体はReview型を返すが、GETの中で呼んでいるAPI内部のfetch系関数はprisma schemaから定義されるReviews型とかTags型とかUsers型を返す。
  - 型名が分かりづらいのでバグの温床になりそう
# 動作確認
- 多分いけてる。ミーティングで確認する