### PR TITLE
fix: emptyReviewをエラーを修正

### DIFF
--- a/constants/index.ts
+++ b/constants/index.ts
@@ -5,7 +5,12 @@ export const emptyReview: Review = {
   content: "",
   paper_title: "",
   paper_data: {},
-  user_id: "",
+  user_info: {
+    id: "-1",
+    name: "Preview",
+    role: "Test",
+    created_at: "",
+  },
   created_at: "",
   comments: [],
   tags: [],


### PR DESCRIPTION
# 概要
#48 

# やったこと
user_idを削除して，空のuser_infoを追加

# 動作確認
エディタ上でエラーの解消は確認