### PR TITLE
Feature/#65 レビューのDELETE APIを実装

### DIFF
--- a/app/api/reviews/[id]/route.ts
+++ b/app/api/reviews/[id]/route.ts
@@ -58,11 +58,11 @@ async function fetchUser(userId: string): Promise<Users[]> {
   }
 }
 
-async function deleteReview(reviewId: number) {
+async function deleteReview(reviewId: number): Promise<number> {
   try {
-    await prisma.$executeRaw`
-    DELETE FROM "Reviews"
-    WHERE id = ${reviewId};`;
+    const res = await prisma.$executeRaw`
+        DELETE FROM "Reviews" WHERE id = ${reviewId};`;
+    return res;
   } catch (error) {
     throw new Error("failed to delete review.");
   }

--- a/app/api/reviews/[id]/route.ts
+++ b/app/api/reviews/[id]/route.ts
@@ -58,6 +58,16 @@ async function fetchUser(userId: string): Promise<Users[]> {
   }
 }
 
+async function deleteReview(reviewId: number) {
+  try {
+    await prisma.$executeRaw`
+    DELETE FROM "Reviews"
+    WHERE id = ${reviewId};`;
+  } catch (error) {
+    throw new Error("failed to delete review.");
+  }
+}
+
 export async function GET(
   request: NextRequest,
   { params }: { params: { id: string } },
@@ -96,6 +106,27 @@ export async function GET(
     console.error(error);
     return NextResponse.json(
       { error: `Failed to fetch review with ID = ${params.id}` },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  try {
+    // ReviewIdをnumberに変換
+    const reviewId = parseInt(params.id);
+    if (isNaN(reviewId)) {
+      return NextResponse.json({ error: "Invalid review ID" }, { status: 400 });
+    }
+    console.log(reviewId);
+    const res = await deleteReview(reviewId);
+    return NextResponse.json(res, { status: 200 });
+  } catch (error) {
+    return NextResponse.json(
+      { error: `Failed to delete review with ID = ${params.id}` },
       { status: 500 },
     );
   }

--- a/app/api/reviews/[id]/route.ts
+++ b/app/api/reviews/[id]/route.ts
@@ -121,7 +121,6 @@ export async function DELETE(
     if (isNaN(reviewId)) {
       return NextResponse.json({ error: "Invalid review ID" }, { status: 400 });
     }
-    console.log(reviewId);
     const res = await deleteReview(reviewId);
     return NextResponse.json(res, { status: 200 });
   } catch (error) {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,8 +27,8 @@ model Comments {
   review_id  Int
   user_id    String
   created_at DateTime @default(now()) @db.Timestamptz(6)
-  review     Reviews  @relation(fields: [review_id], references: [id])
-  user       Users    @relation(fields: [user_id], references: [id])
+  review     Reviews  @relation(fields: [review_id], references: [id], onDelete: Cascade) 
+  user       Users    @relation(fields: [user_id], references: [id], onDelete: Cascade)
   ReviewsToComments ReviewsToComments[]
 }
 


### PR DESCRIPTION
## 概要
/api/reviews/[id]/のDELETEメソッドを実装 #65 
## やったこと
- DBの設計を更新
  - CommentsテーブルのReviewsテーブルに対する関係に、`onDelete Cascade`を追加
  - Reviewsのレコードが削除されたときに、Commentsのレコードも削除される
- `deleteReview(reviewId : number)`の実装
- DELETEメソッドの実装
## 特にレビューしてほしいところ
## 保留していること
- エラーハンドリング
## 動作確認
- ローカルで確認済み