### PR TITLE
issue-#89-User型の再定義

### DIFF
--- a/app/api/reviews/[id]/route.ts
+++ b/app/api/reviews/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { Paper, Review, Tag } from "@/type";
+import { Paper, Review, Tag, User } from "@/type";
 import { prisma } from "@/lib/prisma/prisma-client";
 import { Reviews, Users, Tags, Comments, ReviewsToTags } from "@prisma/client";
 
@@ -163,7 +163,15 @@ export async function GET(
       content: review[0].content,
       paper_title: review[0].paper_title,
       paper_data: review[0].paper_data as Paper,
-      user_info: user[0],
+      user_info: {
+        id: user[0].id,
+        name: user[0].name,
+        role: user[0].role,
+        created_at: user[0].created_at,
+        works: [],
+        fields: [],
+        affiliations: [],
+      } as User,
       comments: comments,
       tags: tags,
       created_at: review[0].created_at,

--- a/app/api/reviews/[id]/route.ts
+++ b/app/api/reviews/[id]/route.ts
@@ -114,11 +114,22 @@ async function fetchCommentsByReviewId(reviewId: number): Promise<Comments[]> {
   }
 }
 
-async function fetchUser(userId: string): Promise<Users[]> {
+async function fetchUser(userId: string): Promise<User[]> {
   try {
-    const userData = await prisma.$queryRaw<Users[]>`
-        SELECT * FROM "Users" WHERE id = ${userId};`;
-
+    const userData = await prisma.$queryRaw<User[]>`
+        SELECT
+          u.*,
+          json_agg(DISTINCT f.*) AS fields,
+          json_agg(DISTINCT w.*) AS works,
+          json_agg(DISTINCT a.*) AS affiliations
+        FROM "Users" u
+        LEFT JOIN "_FieldsToUsers" ftu ON u.id = ftu.user_id
+        LEFT JOIN "Fields" f ON ftu.field_id = f.id
+        LEFT JOIN "Works" w ON u.id = w.user_id
+        LEFT JOIN "_AffiliationsToUsers" atu ON u.id = atu.user_id
+        LEFT JOIN "Affiliations" a ON atu.affiliation_id = a.id
+        WHERE u.id = ${userId}
+        GROUP BY u.id, f.id, w.id, a.id;`;
     return userData;
   } catch (error) {
     console.log(error);
@@ -163,15 +174,7 @@ export async function GET(
       content: review[0].content,
       paper_title: review[0].paper_title,
       paper_data: review[0].paper_data as Paper,
-      user_info: {
-        id: user[0].id,
-        name: user[0].name,
-        role: user[0].role,
-        created_at: user[0].created_at,
-        works: [],
-        fields: [],
-        affiliations: [],
-      } as User,
+      user_info: user[0],
       comments: comments,
       tags: tags,
       created_at: review[0].created_at,

--- a/app/api/reviews/route.ts
+++ b/app/api/reviews/route.ts
@@ -192,7 +192,21 @@ async function fetchReviews(
         GROUP BY r.id, u.id
         ORDER BY r.created_at DESC;`;
     }
-    return reviews;
+
+    const reviewDatas = reviews.map((review) => ({
+      ...review,
+      user_info: {
+        id: review.user_info.id,
+        name: review.user_info.name,
+        role: review.user_info.role,
+        created_at: review.user_info.created_at,
+        works: review.user_info.works || [],
+        fields: review.user_info.fields || [],
+        affiliations: review.user_info.affiliations || [],
+      },
+    }));
+
+    return reviewDatas;
   } catch (error) {
     console.error(error);
     throw new Error("Failed to fetch all reviews.");

--- a/app/api/reviews/route.ts
+++ b/app/api/reviews/route.ts
@@ -25,14 +25,17 @@ async function fetchReviews(
     let reviews: Review[];
     if (!tag && !userId && !affiliationId) {
       reviews = await prisma.$queryRaw<Review[]>`
-        SELECT
-            r.*,
-            json_build_object(
-              'id', u.id,
-              'name', u.name,
-              'role', u.role,
-              'created_at', u.created_at
-            ) AS user_info,
+        SELECT 
+          r.*,
+          json_build_object(
+            'id', u.id,
+            'name', u.name,
+            'role', u.role,
+            'created_at', u.created_at,
+            'fields', json_agg(DISTINCT f.*),
+            'works', json_agg(DISTINCT w.*),
+            'affiliations', json_agg(DISTINCT a.*)
+          ) AS user_info,
             json_agg(json_build_object(
               'id', t.id,
               'name', t.name,
@@ -40,27 +43,40 @@ async function fetchReviews(
             )) AS tags
         FROM "Reviews" r
         LEFT JOIN "Users" u ON r.user_id = u.id
+        LEFT JOIN "_FieldsToUsers" ftu ON u.id = ftu.user_id
+        LEFT JOIN "Fields" f ON ftu.field_id = f.id
+        LEFT JOIN "Works" w ON u.id = w.user_id
+        LEFT JOIN "_AffiliationsToUsers" atu ON u.id = atu.user_id
+        LEFT JOIN "Affiliations" a ON atu.affiliation_id = a.id
         LEFT JOIN "_ReviewsToTags" rtt ON r.id = rtt.review_id
         LEFT JOIN "Tags" t ON rtt.tag_id = t.id
-        GROUP BY r.id, u.id
+        GROUP BY r.id, u.id, f.id, w.id, a.id
         ORDER BY r.created_at DESC;`;
     } else if (!tag && userId && !affiliationId) {
       reviews = await prisma.$queryRaw<Review[]>`
-        SELECT
-            r.*,
-            json_build_object(
-              'id', u.id,
-              'name', u.name,
-              'role', u.role,
-              'created_at', u.created_at
-            ) AS user_info,
-            json_agg(json_build_object(
+        SELECT 
+          r.*,
+          json_build_object(
+            'id', u.id,
+            'name', u.name,
+            'role', u.role,
+            'created_at', u.created_at,
+            'fields', json_agg(DISTINCT f.*),
+            'works', json_agg(DISTINCT w.*),
+            'affiliations', json_agg(DISTINCT a.*)
+          ) AS user_info,
+           json_agg(json_build_object(
               'id', t.id,
               'name', t.name,
               'created_at', t.created_at
             )) AS tags
         FROM "Reviews" r
         LEFT JOIN "Users" u ON r.user_id = u.id
+        LEFT JOIN "_FieldsToUsers" ftu ON u.id = ftu.user_id
+        LEFT JOIN "Fields" f ON ftu.field_id = f.id
+        LEFT JOIN "Works" w ON u.id = w.user_id
+        LEFT JOIN "_AffiliationsToUsers" atu ON u.id = atu.user_id
+        LEFT JOIN "Affiliations" a ON atu.affiliation_id = a.id
         LEFT JOIN "_ReviewsToTags" rtt ON r.id = rtt.review_id
         LEFT JOIN "Tags" t ON rtt.tag_id = t.id
         WHERE r.user_id = ${userId}
@@ -68,21 +84,29 @@ async function fetchReviews(
         ORDER BY r.created_at DESC;`;
     } else if (tag && !userId && !affiliationId) {
       reviews = await prisma.$queryRaw<Review[]>`
-        SELECT
-            r.*,
-            json_build_object(
-              'id', u.id,
-              'name', u.name,
-              'role', u.role,
-              'created_at', u.created_at
-            ) AS user_info,
-            json_agg(json_build_object(
+        SELECT 
+          r.*,
+          json_build_object(
+            'id', u.id,
+            'name', u.name,
+            'role', u.role,
+            'created_at', u.created_at,
+            'fields', json_agg(DISTINCT f.*),
+            'works', json_agg(DISTINCT w.*),
+            'affiliations', json_agg(DISTINCT a.*)
+          ) AS user_info,
+           json_agg(json_build_object(
               'id', t.id,
               'name', t.name,
               'created_at', t.created_at
             )) AS tags
         FROM "Reviews" r
         LEFT JOIN "Users" u ON r.user_id = u.id
+        LEFT JOIN "_FieldsToUsers" ftu ON u.id = ftu.user_id
+        LEFT JOIN "Fields" f ON ftu.field_id = f.id
+        LEFT JOIN "Works" w ON u.id = w.user_id
+        LEFT JOIN "_AffiliationsToUsers" atu ON u.id = atu.user_id
+        LEFT JOIN "Affiliations" a ON atu.affiliation_id = a.id
         LEFT JOIN "_ReviewsToTags" rtt ON r.id = rtt.review_id
         LEFT JOIN "Tags" t ON rtt.tag_id = t.id
         WHERE r.id IN (
@@ -94,24 +118,31 @@ async function fetchReviews(
         ORDER BY r.created_at DESC;`;
     } else if (tag && !userId && affiliationId) {
       reviews = await prisma.$queryRaw<Review[]>`
-        SELECT
-            r.*,
-            json_build_object(
-              'id', u.id,
-              'name', u.name,
-              'role', u.role,
-              'created_at', u.created_at
-            ) AS user_info,
-            json_agg(json_build_object(
+        SELECT 
+          r.*,
+          json_build_object(
+            'id', u.id,
+            'name', u.name,
+            'role', u.role,
+            'created_at', u.created_at,
+            'fields', json_agg(DISTINCT f.*),
+            'works', json_agg(DISTINCT w.*),
+            'affiliations', json_agg(DISTINCT a.*)
+          ) AS user_info,
+           json_agg(json_build_object(
               'id', t.id,
               'name', t.name,
               'created_at', t.created_at
             )) AS tags
         FROM "Reviews" r
         LEFT JOIN "Users" u ON r.user_id = u.id
+        LEFT JOIN "_FieldsToUsers" ftu ON u.id = ftu.user_id
+        LEFT JOIN "Fields" f ON ftu.field_id = f.id
+        LEFT JOIN "Works" w ON u.id = w.user_id
+        LEFT JOIN "_AffiliationsToUsers" atu ON u.id = atu.user_id
+        LEFT JOIN "Affiliations" a ON atu.affiliation_id = a.id
         LEFT JOIN "_ReviewsToTags" rtt ON r.id = rtt.review_id
         LEFT JOIN "Tags" t ON rtt.tag_id = t.id
-        LEFT JOIN "_AffiliationsToUsers" atu ON u.id = atu.user_id
         WHERE atu.affiliation_id = ${affiliationId}
           AND r.id IN (
             SELECT rtt.review_id
@@ -122,91 +153,100 @@ async function fetchReviews(
         ORDER BY r.created_at DESC;`;
     } else if (tag && userId && !affiliationId) {
       reviews = await prisma.$queryRaw<Review[]>`
-      SELECT
+        SELECT 
             r.*,
             json_build_object(
               'id', u.id,
               'name', u.name,
               'role', u.role,
-              'created_at', u.created_at
+              'created_at', u.created_at,
+              'fields', json_agg(DISTINCT f.*),
+              'works', json_agg(DISTINCT w.*),
+              'affiliations', json_agg(DISTINCT a.*)
             ) AS user_info,
             json_agg(json_build_object(
-              'id', t.id,
-              'name', t.name,
-              'created_at', t.created_at
-            )) AS tags
-        FROM "Reviews" r
-        LEFT JOIN "Users" u ON r.user_id = u.id
-        LEFT JOIN "_ReviewsToTags" rtt ON r.id = rtt.review_id
-        LEFT JOIN "Tags" t ON rtt.tag_id = t.id
+                'id', t.id,
+                'name', t.name,
+                'created_at', t.created_at
+              )) AS tags
+          FROM "Reviews" r
+          LEFT JOIN "Users" u ON r.user_id = u.id
+          LEFT JOIN "_FieldsToUsers" ftu ON u.id = ftu.user_id
+          LEFT JOIN "Fields" f ON ftu.field_id = f.id
+          LEFT JOIN "Works" w ON u.id = w.user_id
+          LEFT JOIN "_AffiliationsToUsers" atu ON u.id = atu.user_id
+          LEFT JOIN "Affiliations" a ON atu.affiliation_id = a.id
+          LEFT JOIN "_ReviewsToTags" rtt ON r.id = rtt.review_id
+          LEFT JOIN "Tags" t ON rtt.tag_id = t.id
         WHERE r.user_id = ${userId}
           AND r.id IN (
             SELECT rtt.review_id
             FROM "_ReviewsToTags" rtt
             JOIN "Tags" t ON rtt.tag_id = t.id
             WHERE t.name = ${tag})
-        GROUP BY r.id, u.id
-        ORDER BY r.created_at DESC;`;
+          GROUP BY r.id, u.id
+          ORDER BY r.created_at DESC;`;
     } else if (!tag && !userId && affiliationId) {
       reviews = await prisma.$queryRaw<Review[]>`
-        SELECT
-            r.*,
-            json_build_object(
-              'id', u.id,
-              'name', u.name,
-              'role', u.role,
-              'created_at', u.created_at
-            ) AS user_info,
-            json_agg(json_build_object(
+        SELECT 
+          r.*,
+          json_build_object(
+            'id', u.id,
+            'name', u.name,
+            'role', u.role,
+            'created_at', u.created_at,
+            'fields', json_agg(DISTINCT f.*),
+            'works', json_agg(DISTINCT w.*),
+            'affiliations', json_agg(DISTINCT a.*)
+          ) AS user_info,
+           json_agg(json_build_object(
               'id', t.id,
               'name', t.name,
               'created_at', t.created_at
             )) AS tags
         FROM "Reviews" r
         LEFT JOIN "Users" u ON r.user_id = u.id
+        LEFT JOIN "_FieldsToUsers" ftu ON u.id = ftu.user_id
+        LEFT JOIN "Fields" f ON ftu.field_id = f.id
+        LEFT JOIN "Works" w ON u.id = w.user_id
+        LEFT JOIN "_AffiliationsToUsers" atu ON u.id = atu.user_id
+        LEFT JOIN "Affiliations" a ON atu.affiliation_id = a.id
         LEFT JOIN "_ReviewsToTags" rtt ON r.id = rtt.review_id
         LEFT JOIN "Tags" t ON rtt.tag_id = t.id
-        LEFT JOIN "_AffiliationsToUsers" atu ON u.id = atu.user_id
         WHERE atu.affiliation_id = ${affiliationId}
         GROUP BY r.id, u.id
         ORDER BY r.created_at DESC;`;
     } else {
       reviews = await prisma.$queryRaw<Review[]>`
-        SELECT
-            r.*,
-            json_build_object(
-              'id', u.id,
-              'name', u.name,
-              'role', u.role,
-              'created_at', u.created_at
-            ) AS user_info,
-            json_agg(json_build_object(
+        SELECT 
+          r.*,
+          json_build_object(
+            'id', u.id,
+            'name', u.name,
+            'role', u.role,
+            'created_at', u.created_at,
+            'fields', json_agg(DISTINCT f.*),
+            'works', json_agg(DISTINCT w.*),
+            'affiliations', json_agg(DISTINCT a.*)
+          ) AS user_info,
+           json_agg(json_build_object(
               'id', t.id,
               'name', t.name,
               'created_at', t.created_at
             )) AS tags
         FROM "Reviews" r
         LEFT JOIN "Users" u ON r.user_id = u.id
+        LEFT JOIN "_FieldsToUsers" ftu ON u.id = ftu.user_id
+        LEFT JOIN "Fields" f ON ftu.field_id = f.id
+        LEFT JOIN "Works" w ON u.id = w.user_id
+        LEFT JOIN "_AffiliationsToUsers" atu ON u.id = atu.user_id
+        LEFT JOIN "Affiliations" a ON atu.affiliation_id = a.id
         LEFT JOIN "_ReviewsToTags" rtt ON r.id = rtt.review_id
         LEFT JOIN "Tags" t ON rtt.tag_id = t.id
         GROUP BY r.id, u.id
         ORDER BY r.created_at DESC;`;
     }
-
-    const reviewDatas = reviews.map((review) => ({
-      ...review,
-      user_info: {
-        id: review.user_info.id,
-        name: review.user_info.name,
-        role: review.user_info.role,
-        created_at: review.user_info.created_at,
-        works: review.user_info.works || [],
-        fields: review.user_info.fields || [],
-        affiliations: review.user_info.affiliations || [],
-      },
-    }));
-
-    return reviewDatas;
+    return reviews;
   } catch (error) {
     console.error(error);
     throw new Error("Failed to fetch all reviews.");

--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma/prisma-client";
-import { UserDetail } from "@/type";
+import { User } from "@/type";
 
-async function fetchUser(userId: string): Promise<UserDetail[]> {
+async function fetchUser(userId: string): Promise<User[]> {
   try {
-    const user = await prisma.$queryRaw<UserDetail[]>`
+    const user = await prisma.$queryRaw<User[]>`
         SELECT
         users.*,
         (SELECT json_agg(json_build_object(

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma/prisma-client";
-import { UserDetail, Work, Field, Affiliation } from "@/type";
+import { User, Work, Field, Affiliation } from "@/type";
 
-async function fetchUsers(affiliationId: number | null): Promise<UserDetail[]> {
+async function fetchUsers(affiliationId: number | null): Promise<User[]> {
   try {
-    let users: UserDetail[];
+    let users: User[];
     if (affiliationId) {
       users = await prisma.$queryRaw`
         SELECT
@@ -38,7 +38,7 @@ async function fetchUsers(affiliationId: number | null): Promise<UserDetail[]> {
     ORDER BY users.created_at DESC;
         `;
     } else {
-      users = await prisma.$queryRaw<UserDetail[]>`
+      users = await prisma.$queryRaw<User[]>`
         SELECT
       users.*,
         (SELECT json_agg(json_build_object(
@@ -121,9 +121,9 @@ async function setAffiliation(
   }
 }
 
-async function setUser(userData: UserDetail) {
+async function setUser(userData: User) {
   try {
-    const newUserData = await prisma.$queryRaw<UserDetail[]>`
+    const newUserData = await prisma.$queryRaw<User[]>`
         INSERT INTO "Users" (id, name, role)
         VALUES (${userData.id}, ${userData.name}, ${userData.role})
         ON CONFLICT (id) DO UPDATE

--- a/components/Review.tsx
+++ b/components/Review.tsx
@@ -4,7 +4,7 @@ import remarkBreaks from "remark-breaks";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import Link from "next/link";
 import { Separator } from "./ui/separator";
-import { Review as ReviewType, User } from "@/type";
+import { Review as ReviewType } from "@/type";
 import { Modal } from "./review/Modal";
 import clsx from "clsx";
 import PaperData from "./PaperData";

--- a/components/form/OnboardingForm.tsx
+++ b/components/form/OnboardingForm.tsx
@@ -82,12 +82,6 @@ export function OnboadingForm({ userId }: { userId: string }) {
     isLoading.current = true;
     const now = Date();
 
-    const userData: User = {
-      id: userId,
-      name: data.username,
-      role: data.role,
-      created_at: now,
-    };
     const affiliationData: Affiliation = {
       id: 0,
       name: data.affiliation,
@@ -104,14 +98,23 @@ export function OnboadingForm({ userId }: { userId: string }) {
       user_id: userId,
       created_at: now,
     };
+    const userData: User = {
+      id: userId,
+      name: data.username,
+      role: data.role,
+      created_at: now,
+      works: [workData],
+      fields: [fieldData],
+      affiliations: [affiliationData],
+    };
 
     let affiliationId = await fetchAffiliationIdByAffiliationName(
-      data.affiliation
+      data.affiliation,
     );
     if (affiliationId === 0) {
       setAffiliation(affiliationData);
       affiliationId = await fetchAffiliationIdByAffiliationName(
-        data.affiliation
+        data.affiliation,
       );
     }
     let fieldId = await fetchFieldIdByFieldName(data.field);
@@ -165,12 +168,12 @@ export function OnboadingForm({ userId }: { userId: string }) {
                       role="combobox"
                       className={cn(
                         "w-full justify-between",
-                        !field.value && "text-muted-foreground"
+                        !field.value && "text-muted-foreground",
                       )}
                     >
                       {field.value
                         ? affiliations.find(
-                            (affiliation) => affiliation.value === field.value
+                            (affiliation) => affiliation.value === field.value,
                           )?.label
                         : "所属を選択"}
                       <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
@@ -196,7 +199,7 @@ export function OnboadingForm({ userId }: { userId: string }) {
                                 "mr-2 h-4 w-4",
                                 affiliation.value === field.value
                                   ? "opacity-100"
-                                  : "opacity-0"
+                                  : "opacity-0",
                               )}
                             />
                             {affiliation.label}
@@ -231,7 +234,7 @@ export function OnboadingForm({ userId }: { userId: string }) {
                       role="combobox"
                       className={cn(
                         "w-full justify-between",
-                        !field.value && "text-muted-foreground"
+                        !field.value && "text-muted-foreground",
                       )}
                     >
                       {field.value
@@ -260,7 +263,7 @@ export function OnboadingForm({ userId }: { userId: string }) {
                                 "mr-2 h-4 w-4",
                                 f.value === field.value
                                   ? "opacity-100"
-                                  : "opacity-0"
+                                  : "opacity-0",
                               )}
                             />
                             {f.label}

--- a/type/index.ts
+++ b/type/index.ts
@@ -60,14 +60,6 @@ export type Tag = {
   created_at: string | Date;
 };
 
-// Users Table: id, user_id, name, role, created_at
-export type User = {
-  id: string;
-  name: string;
-  role: string | null; // いったん　Student or Teacher
-  created_at: string | Date;
-};
-
 // Works Table: id, url, user_id, created_at
 export type Work = {
   id: number;
@@ -76,7 +68,7 @@ export type Work = {
   created_at: string | Date;
 };
 
-export type UserDetail = {
+export type User = {
   id: string;
   name: string;
   role: string | null; // いったん　Student or Teacher
@@ -85,3 +77,11 @@ export type UserDetail = {
   fields: Field[];
   affiliations: Affiliation[];
 };
+
+// deprecated
+// export type User = {
+//   id: string;
+//   name: string;
+//   role: string | null; // いったん　Student or Teacher
+//   created_at: string | Date;
+// };


### PR DESCRIPTION
## 概要
#89 に対処。User型を再定義した
## やったこと
- User型の再定義
  - User型にworks, affilaitions, fieldsを追加
- User型更新に伴う影響範囲を修正
## 特にレビューしてほしいところ
- 218cc605328fed0d71378d056c11c9e0ec77bafb
- レビュー取得時に、ユーザー情報をnullや空配列にせずに実際にクエリを飛ばして取得することにした。意図としては、APIを叩いた際の戻り値がフロントでどう使用されるかどうか、という事とAPIの仕様を切り離して考えたいから
  - APIの仕様とフロントでの使い方をできるだけ切り離したいから
## 保留していること
とくになし
## 動作確認
ローカル環境で動作確認済み
