### PR TITLE
# 70 fetchUsersByAffiliationId()をAPIを用いた実装に変更

### DIFF
--- a/actions/user.action.ts
+++ b/actions/user.action.ts
@@ -48,16 +48,17 @@ export async function fetchUserIdsByLabId(labId: string) {
 */
 
 export async function fetchUsersByAffiliationId(
-  affiliationId: number
+  affiliationId: number,
 ): Promise<User[]> {
   try {
-    const usersData = await prisma.$queryRaw<User[]>`
-      SELECT "Users".*
-      FROM "Users"
-      JOIN "_AffiliationsToUsers" ON "Users".id = "_AffiliationsToUsers".user_id
-      JOIN "Affiliations" ON "_AffiliationsToUsers".affiliation_id = "Affiliations".id
-      WHERE "Affiliations".id = ${affiliationId};`;
+    const requestUrl = new URL(
+      `${process.env.API_URL}/users?affiliationId=${affiliationId}`,
+    );
+    const response = await fetch(requestUrl, {
+      method: "GET",
+    });
 
+    const usersData = await response.json();
     return usersData;
   } catch (error) {
     console.log(error);


### PR DESCRIPTION
## 概要
fetchUsersByAffiliationId()をAPIを用いた実装に変更

## やったこと
- fetchUsersByAffiliationId()をAPIを用いた実装に変更

## 特にレビューしてほしいところ
特になし

## 保留していること
特になし

## 動作確認
ローカル環境で動作確認済み
